### PR TITLE
add support for private apps and custom properties

### DIFF
--- a/HubspotConfig.cs
+++ b/HubspotConfig.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+
+class HubspotConfig {
+  public string APIKEY_DEPRECATED;
+  public string HUBSPOT_PRIVATE_APP_KEY;
+  public IDictionary<string, string> HUBSPOT_PROPERTIES;
+}

--- a/MarketPlaceToHubSpot.cs
+++ b/MarketPlaceToHubSpot.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using System.Net.Http;
 using System.Collections.Generic;
 using System.Text;
+using System.Linq;
 
 namespace marketplaceleadstohubspot
 {
@@ -28,16 +29,38 @@ namespace marketplaceleadstohubspot
 	    .AddEnvironmentVariables() 
 	    .Build();
         
-        // Hubspot API information
-	    string hubspotAPIKey = config["hubspotAPIKEY"];
-        string baseURI = "https://api.hubapi.com/contacts/v1/contact/?hapikey=";
-        string URI = baseURI + hubspotAPIKey;
+        // Hubspot API configuration:
+        // 
+        // hubspotAPIKEY: the old API KEY (not supported anymore after November 30 2022)
+        // See https://developers.hubspot.com/changelog/upcoming-api-key-sunset
+        // 
+        // HUBSPOT_PRIVATE_APP_KEY: a private app key, should start with 
+        // See https://developers.hubspot.com/docs/api/migrate-an-api-key-integration-to-a-private-app
+        // 
+        // HUBSPOT_PROPERTIES: the list of coma-separate properties to be synced
+        // they should exist in hubspot (first part is how they are found in the AppSource second is how they should go hubspot). 
+        // https://appsource.microsoft.com/en-us/product/office/WXAAAA?mktcmpid=1234
+        // Examples:
+        // leadSource, mtkcmpid, partnerid
+        // leadSource=lead_source, actionCode=action_code, mktcmpid=mktcmpid
+
+        var hubspotConfig = new HubspotConfig {
+                APIKEY_DEPRECATED = config["hubspotAPIKEY"],
+                HUBSPOT_PRIVATE_APP_KEY = config["HUBSPOT_PRIVATE_APP_KEY"],
+                HUBSPOT_PROPERTIES = (config["HUBSPOT_PROPERTIES"] ?? "")
+                    .Split(",")
+                    .Select(x => x.Trim())
+                    .Where(x => !string.IsNullOrEmpty(x))
+                    .ToDictionary(v => v.Split("=").First(), v => v.Split("=").Last())
+            };
 
         // Process leads from the marketplace
         string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
         Lead deserializedMarketplaceLead = JsonConvert.DeserializeObject<Lead>(requestBody);
   
     
+        var description = deserializedMarketplaceLead.description;
+
         // You can use as much properties as you want, as long as they exist in HubSpot.
         // Do a HTTP get to https://api.hubapi.com/properties/v1/contacts/properties?hapikey=<APIKEY> to check
         var details = new HubSpotContactPoperties();
@@ -53,32 +76,72 @@ namespace marketplaceleadstohubspot
             new Property { property = "city", value = "NotProvidedFromAzureMarketPlace" },
             new Property { property = "state", value = "NotProvidedFromAzureMarketPlace" },
             new Property { property = "zip", value = "NotProvidedFromAzureMarketPlace" },
-            // You could use deserializedMarketplaceLead.leadSource here but it needs to exist in Hubspot!
-            new Property { property = "lead_source", value = "Microsoft.com Referral"},
-            new Property { property = "message", value = "Offer Title: " + deserializedMarketplaceLead.offerTitle }
-        };
+            new Property { property = "message", value = "Offer Title: " + deserializedMarketplaceLead.offerTitle + " Description: " + description },
+            };
+
+            // You could use other properties but they need to exists in hubspot (and mapped in the config)
+            void TryAddProperty(string appSourceName, string value) 
+            {
+                if (hubspotConfig.HUBSPOT_PROPERTIES.TryGetValue(appSourceName, out var huspotName))
+                {
+                    details.properties.Add(new Property { property = huspotName, value = value });
+                }
+            }
+
+            TryAddProperty("leadSource", deserializedMarketplaceLead.leadSource);
+            TryAddProperty("actionCode", deserializedMarketplaceLead.actionCode);
+
+            // if extra parameters are found on AppSource the URL, they are passed in in description as JSON
+            // Example link: https://appsource.microsoft.com/en-us/product/office/WXAAAA?mktcmpid=1234&partnerid=98765
+            if (!string.IsNullOrEmpty(description) && description.StartsWith("{") && description.EndsWith("}"))
+            {
+                var json = JsonConvert.DeserializeObject<Dictionary<string, string>>(deserializedMarketplaceLead.description);
+                foreach (var kvp in json)
+                {
+                    TryAddProperty(kvp.Key, kvp.Value);
+                }
+            }
+
         // Serialize details to jsonBody
         string jsonBody = JsonConvert.SerializeObject(details);
 
         // Write Leads to HubSpot
-        string result = await WriteLeadHubSpot(URI, jsonBody);
+        string result = await WriteLeadHubSpot(jsonBody, hubspotConfig);
 
         // Methods for HTTP Client, and posting to HubSpot
         // Create HTTP client
-        static HttpClient HTTPClient()
+        static HttpClient HTTPClient(string bearerToken)
         {
             HttpClient httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Clear();
+            
+            // use bearer token for new private app authentication
+            if (!string.IsNullOrEmpty(bearerToken))
+                httpClient.DefaultRequestHeaders.Add("Authorization", "Bearer " + bearerToken);
+
             httpClient.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
             return httpClient;
         }
 
         // Write contact to hubspot
-        static async Task<string> WriteLeadHubSpot(string URI, string jsonBody)
+        static async Task<string> WriteLeadHubSpot(string jsonBody, HubspotConfig keys)
         {
-            HttpClient httpClient = HTTPClient();
+            // if still using the deprecated API KEY, append it to the URL
+            string hapikeyParam = string.IsNullOrEmpty(keys.HUBSPOT_PRIVATE_APP_KEY) ? ("?hapikey=" + keys.APIKEY_DEPRECATED) : string.Empty;
+            string URI = "https://api.hubapi.com/contacts/v1/contact/" + hapikeyParam;
+
+            HttpClient httpClient = HTTPClient(keys.HUBSPOT_PRIVATE_APP_KEY);
             StringContent postBody = new StringContent(jsonBody, Encoding.UTF8, "application/json");
             HttpResponseMessage response = await httpClient.PostAsync(URI, postBody);
+
+            // log huspot error so that we know if there is a problem
+            if (!response.IsSuccessStatusCode) {
+                if (response.Content.Headers.ContentType.MediaType == "application/json") 
+                {
+                    string huspotMessage = await response.Content.ReadAsStringAsync();
+                    throw new HttpRequestException(huspotMessage);
+                }
+            }
             response.EnsureSuccessStatusCode();
             string responseBody = await response.Content.ReadAsStringAsync();
             return responseBody;

--- a/README.MD
+++ b/README.MD
@@ -3,15 +3,29 @@ This Azure Function accepts leads from Azure Marketplace and passes them to HubS
 
 ## Requirements
 - Azure Function App
-- [Hubspot API Key](https://knowledge.hubspot.com/integrations/how-do-i-get-my-hubspot-api-key?_ga=2.86242584.1279156532.1618828099-380446826.1615450408)
+- [Hubspot Private App Token](https://developers.hubspot.com/docs/api/private-apps#make-api-calls-with-your-app-s-access-token)
+- (deprecated) [Hubspot API Key](https://knowledge.hubspot.com/integrations/how-do-i-get-my-hubspot-api-key?_ga=2.86242584.1279156532.1618828099-380446826.1615450408)
 
 ## Configuration
+
 1. Make sure you have an Azure Function App running on Windows and .Net Core [Howto](https://docs.microsoft.com/en-us/azure/azure-functions/functions-get-started?pivots=programming-language-csharp&WT.mc_id=AZ-MVP-5003649)
 
-2. Add the *hubspotAPIKey* to your app settings. Add the HubSpot API Key as a value
-3. Grab the Function URL from the Azure Portal
-4. Go to your [Azure Marketplace offers](https://partner.microsoft.com/en-us/dashboard/commercial-marketplace/offers) and click on your offering
-5. Go to "Offer Setup" and under "Customer Leads" configure the HTTPS endpoint for your leads. Be aware that you include the Function key.
+2. Add the *HUBSPOT_PRIVATE_APP_KEY* to your app settings. Add the HubSport private app key as a value.
+(deprecated) Add the *hubspotAPIKey* to your app settings. Add the HubSpot API Key as a value. Please note this is method has been stopped by HubSport November 30, 2022
+
+3. (optional) Add the *HUBSPOT_PROPERTIES* to your app settings if you have additional (to default) properties in HubSpot you want to be filled form the App Source.
+This configuration parameter should contain a list of coma-separated properties with (optional) mapping to hubspot. You can use the standard AppSource properties, i.e. 'actionCode' and 'leadSource', or any custom property that is a part of the URL. Example ('action_code', 'lead_source' and 'mktcmpid' must exist in HubSpot, i.e you should add them manually). If you don't add anything here or omit the propery alltogether, only the default properties (such as user name / company) will be transferred.
+```
+Sample URL:
+https://appsource.microsoft.com/en-us/product/office/WXAAAA?mktcmpid=1234&partnerid=98765
+
+Value for HUBSPOT_PROPERTIES:
+actionCode=action_code, leadSource=lead_source, mktcmpid, partnerid
+```
+
+4. Grab the Function URL from the Azure Portal
+5. Go to your [Azure Marketplace offers](https://partner.microsoft.com/en-us/dashboard/commercial-marketplace/offers) and click on your offering
+6. Go to "Offer Setup" and under "Customer Leads" configure the HTTPS endpoint for your leads. Be aware that you include the Function key.
 
 ## Important
 HubSpot supports many, many fields (properties) that you can use. As long as the property exists in HubSpot you can pass it along with any value you want, or with a value that comes from the Azure Marketplace. The properties need to match exactly. You can query the endpoint: https://api.hubapi.com/properties/v1/contacts/properties?hapikey=APIKEY to verify the existence of a property.
@@ -30,14 +44,11 @@ var details = new HubSpotContactPoperties();
             new Property { property = "city", value = "NotProvidedFromAzureMarketPlace" },
             new Property { property = "state", value = "NotProvidedFromAzureMarketPlace" },
             new Property { property = "zip", value = "NotProvidedFromAzureMarketPlace" },
-            // You could use deserializedMarketplaceLead.leadSource here but it needs to exist in Hubspot!
-            new Property { property = "lead_source", value = "Microsoft.com Referral"},
             new Property { property = "message", value = "Offer Title: " + deserializedMarketplaceLead.offerTitle }
         };
 // Serialize details to jsonBody
 string jsonBody = JsonConvert.SerializeObject(details);
 ```` 
-
 
 ## To Do
 - Add Oauth support

--- a/host.json
+++ b/host.json
@@ -2,9 +2,9 @@
     "version": "2.0",
     "logging": {
         "applicationInsights": {
-            "samplingExcludedTypes": "Request",
             "samplingSettings": {
-                "isEnabled": true
+                "isEnabled": true,
+                "samplingExcludedTypes": "Request"
             }
         }
     }


### PR DESCRIPTION
Hello! 

Thank you for the great project @whaakman!

The things in this PR:
The Hubspot API KEYs are not supported anymore from 30th of November 2022:
https://developers.hubspot.com/changelog/upcoming-api-key-sunset

This pull request adds the support for "private app keys" instead:
https://developers.hubspot.com/docs/api/migrate-an-api-key-integration-to-a-private-app

The private app key can be set using the HUBSPOT_PRIVATE_APP_KEY parameter, similar to hubspotAPIKEY
If the HUBSPOT_PRIVATE_APP_KEY is found in the configuration, the app will use it

Another thing that this adds is configuration for custom properties and minimal error handling (so that you can see in the log what property is invalid in hubspot).

The properties can be configured using HUBSPOT_PROPERTIES configuration key. It is supposed to contain a list of coma-separate proeprties, with optional mapping to huspot. Note that "custom" URL items are also included, to support marketing campaigns for example, or partner id. meaning, the lead URL may look like this:

https://appsource.microsoft.com/en-us/product/office/WXAAAA?mktcmpid=1234&partnerid=98765

If the "mktcmpid" is an enabled property, it will be put to the huspot. To configure (in addition to the app source's leadSource and actionCode:

```
leadSource=lead_source, actionCode=action_code, mktcmpid=mktcmpid
```

Hope you will find this worthwhile. Linked issue #2 